### PR TITLE
Updating discourse_sso_controller

### DIFF
--- a/app/controllers/discourse_mountable_sso/discourse_sso_controller.rb
+++ b/app/controllers/discourse_mountable_sso/discourse_sso_controller.rb
@@ -15,6 +15,7 @@ module DiscourseMountableSso
       discourse_data.each_pair {|k,v| sso.send("#{ k }=", v) }
 
       sso.sso_secret = @config.secret
+      yield sso if block_given?
       redirect_to sso.to_url("#{@config.discourse_url}/session/sso_login")
     end
 


### PR DESCRIPTION
Updating discourse_sso_controller so that the action sso can yield the Single Sign On object and then it can be used to do something else before redirecting.
